### PR TITLE
Poprawione zaproszenie do Slacka

### DIFF
--- a/contact.md
+++ b/contact.md
@@ -8,7 +8,7 @@ menus: header
 
 ## Komunikatory
 
-Głównym kanałem komunikacyjnym i organizacyjnym stowarzyszenia jest slack - [hspomorze.slack.com](https://join.slack.com/t/hspomorze/shared_invite/zt-kstnlyol-AjDRGHUqfK1GVYvi99G47g), do którego również zapraszamy wszystkich gości.
+Głównym kanałem komunikacyjnym i organizacyjnym stowarzyszenia jest slack - [hspomorze.slack.com](/slack), do którego również zapraszamy wszystkich gości.
 
 
 Jeżeli potrzebujesz doraźnie skontaktować się z naszą społecznością, napisz na [Telegramie](https://t.me/hspomorze).

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,3 +33,7 @@
 [[redirects]]
   from = "/jitsi"
   to = "https://meet.jit.si/hsp.sh"
+
+[[redirects]]
+  from = "/slack"
+  to = "https://join.slack.com/t/hs3city/shared_invite/zt-kstnlyol-AjDRGHUqfK1GVYvi99G47g"


### PR DESCRIPTION
Wygląda na to, że link do slacka wygasa co 30 dni. Stworzyłem przekierowanie z `hsp.sh/slack` na aktualne zaproszenie. W ten sposób wystarczy co 30 dni zaktualizować link w jednym miejscu, żeby wszędzie na stronie był aktualny.