### PR TITLE
Fix text decoration in navigation

### DIFF
--- a/_sass/includes/_header.scss
+++ b/_sass/includes/_header.scss
@@ -7,6 +7,8 @@ header {
     float: left;
 }
 
+$nbsp: "\0000a0";
+
 header nav {
     text-transform: lowercase;
     display: inline
@@ -15,15 +17,18 @@ header nav {
         text-decoration: none !important;
     }
     a::after {
-        content: " |";
+        content: "#{$nbsp}|";
         color: $hacker-color;
+        display: inline-block;
     }
     a:first-child::before {
-        content: "[ ";
+        content: "[#{$nbsp}";
         color: $hacker-color;
+        display: inline-block;
     }
     a:last-child::after {
-        content: " ]";
+        content: "#{$nbsp}]";
         color: $hacker-color;
+        display: inline-block;
     }
 }


### PR DESCRIPTION
Before:
<img width="470" alt="image" src="https://user-images.githubusercontent.com/9415789/132667599-b58b6c46-50fd-48a0-a6e2-7647e2d058b1.png">

After:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/9415789/132667676-376e6a9e-9e0e-4c1a-accf-94f889be1148.png">
