### PR TITLE
Change /statut redirect to GitHub Source of Truth

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -51,7 +51,7 @@
 
 [[redirects]]
   from = "/statut"
-  to = "/statut/Statut_HSP_05-03-2022.pdf"
+  to = "https://github.com/hspsh/stowarzyszenie/releases/latest/download/Statut_HSP.pdf"
 
 # legacy stuff
 


### PR DESCRIPTION
The redirect will now point to the latest release of Statut over at https://github.com/hspsh/stowarzyszenie.

In the repository, the Statut is automatically rendered from LaTeX.